### PR TITLE
Fix Catalina WARN and ERROR multiline grouping

### DIFF
--- a/learn/logstash/indexer.conf
+++ b/learn/logstash/indexer.conf
@@ -32,7 +32,7 @@ filter{
   #--------------------
   multiline {
     type => "catalina"
-    pattern => "^(SEVERE|WARNING|INFO|CONFIG|FINE|FINER|FINEST)(.)*"
+    pattern => "^(SEVERE|WARNING|INFO|CONFIG|FINE|FINER|FINEST|WARN|ERROR)(.)*"
     negate => true
     what => "previous"
   }


### PR DESCRIPTION
I'm trying to set up LogStash at my institution and noticed weird grouping of the Catalina log events. Looks like WARN and ERROR are common beginning words that aren't in the multiline filter. Are there others?
